### PR TITLE
one shot prompting

### DIFF
--- a/historyspeaks-server/index.js
+++ b/historyspeaks-server/index.js
@@ -3,6 +3,7 @@ import dotenv from "dotenv";
 import cors from "cors";
 import Groq from "groq-sdk";
 import { createZeroShotPrompt } from "./zeroShot.js";
+import { createOneShotPrompt } from "./oneShot.js";
 
 dotenv.config();
 
@@ -13,9 +14,14 @@ app.use(express.json());
 const groq = new Groq({ apiKey: process.env.GROQ_API_KEY });
 
 app.post("/ask", async (req, res) => {
-  const { question } = req.body;
+  const { question, mode } = req.body;  // mode: "zero" or "one"
 
-  const prompt = createZeroShotPrompt(question);
+  let prompt;
+  if (mode === "one") {
+    prompt = createOneShotPrompt(question);
+  } else {
+    prompt = createZeroShotPrompt(question);
+  }
 
   try {
     const completion = await groq.chat.completions.create({

--- a/historyspeaks-server/oneShot.js
+++ b/historyspeaks-server/oneShot.js
@@ -1,0 +1,13 @@
+export function createOneShotPrompt(question) {
+  return `
+You are a knowledgeable historian.
+
+Example:
+Q: When did the American Civil War start?
+A: The American Civil War started in 1861 and lasted until 1865.
+
+Now answer this question:
+Q: ${question}
+A:
+  `;
+}


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Add one-shot prompting capability to the server

- Implement mode selection between zero-shot and one-shot prompting

- Create new oneShot.js module with example-based prompting


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Client Request"] --> B["Mode Selection"]
  B --> C["Zero-shot Prompt"]
  B --> D["One-shot Prompt"]
  C --> E["Groq API"]
  D --> E
  E --> F["Response"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.js</strong><dd><code>Add mode-based prompt selection logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

historyspeaks-server/index.js

<ul><li>Import new <code>createOneShotPrompt</code> function<br> <li> Add <code>mode</code> parameter extraction from request body<br> <li> Implement conditional prompt selection based on mode<br> <li> Default to zero-shot when mode is not "one"</ul>


</details>


  </td>
  <td><a href="https://github.com/kalviumcommunity/Historical_Figures/pull/13/files#diff-1f6d7e84df2ef99e736fe18975159d9f1e909e833ac31269681507d1011889ea">+8/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>oneShot.js</strong><dd><code>Create one-shot prompting module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

historyspeaks-server/oneShot.js

<ul><li>Create new module for one-shot prompting<br> <li> Implement <code>createOneShotPrompt</code> function with example template<br> <li> Include American Civil War example for demonstration</ul>


</details>


  </td>
  <td><a href="https://github.com/kalviumcommunity/Historical_Figures/pull/13/files#diff-9e0b4365eb5995df9f1be51fcee28eb1765caccdb758a7986f2669e81f26c5c6">+13/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

